### PR TITLE
Harden server for production deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,28 @@ Or configure Claude Desktop manually:
 
 > **Note**: Run `npm run build` after code changes to update the `dist/` folder.
 
+## Deployment
+
+This server is designed to be deployed to cloud platforms like [Render](https://render.com/).
+
+### Platform Configuration (Render Example)
+
+When setting up the service on a platform like Render, use the following settings:
+
+- **Build Command**: `npm install && npm run build`
+- **Start Command**: `npm start`
+
+### Environment Variables
+
+For the server to function correctly in HTTP mode, you must configure the following environment variables. These are obtained from your Azure AD App Registration.
+
+- `MS365_MCP_CLIENT_ID`: **Required**. The Application (client) ID for your Azure AD app.
+- `MS365_MCP_CLIENT_SECRET`: **Required**. The client secret for your Azure AD app.
+- `MS365_MCP_TENANT_ID`: **Required**. The Directory (tenant) ID, or `common` for multi-tenant applications.
+- `NODE_ENV`: Recommended. Set to `production` for optimal performance.
+
+The server will fail to start if `MS365_MCP_CLIENT_ID` or `MS365_MCP_CLIENT_SECRET` are not provided when running in HTTP mode.
+
 ### Authentication
 
 > ⚠️ You must authenticate before using tools.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12344,20 +12344,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "node_modules/tsup/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/tsx": {
       "version": "4.19.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
@@ -12759,20 +12745,6 @@
         }
       }
     },
-    "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.3.tgz",
@@ -12995,20 +12967,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate": "node bin/generate-graph-client.mjs",
     "postinstall": "npm run generate",
     "build": "tsup",
+    "start": "node dist/index.js --http",
     "test": "vitest run",
     "test:watch": "vitest",
     "dev": "tsx src/index.ts",

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,7 +87,17 @@ class MicrosoftGraphServer {
     }
 
     if (this.options.http) {
-      const port = typeof this.options.http === 'string' ? parseInt(this.options.http) : 3000;
+      const port = parseInt(
+        process.env.PORT || (typeof this.options.http === 'string' ? this.options.http : '3000'),
+        10
+      );
+
+      if (!process.env.MS365_MCP_CLIENT_ID || !process.env.MS365_MCP_CLIENT_SECRET) {
+        logger.error(
+          'FATAL: MS365_MCP_CLIENT_ID and MS365_MCP_CLIENT_SECRET environment variables are required in HTTP mode.'
+        );
+        process.exit(1);
+      }
 
       const app = express();
       app.use(express.json());


### PR DESCRIPTION
This commit prepares the server for a production deployment on platforms like Render.

The following changes were made:

- A `start` script was added to `package.json` to provide a standard way to run the application in production with HTTP mode enabled.

- The server is updated to respect the `PORT` environment variable, which is a common requirement for cloud deployment platforms.

- A startup check is added to `src/server.ts`. The server will now exit with an error if it is started in HTTP mode without the required `MS365_MCP_CLIENT_ID` and `MS365_MCP_CLIENT_SECRET` environment variables. This prevents running in a misconfigured state.

- The `README.md` is updated with a new "Deployment" section that provides clear instructions on how to deploy the server, including the necessary build/start commands and environment variables.